### PR TITLE
Delete intermediate questions

### DIFF
--- a/client/src/components/Froms/QuestionForm.js
+++ b/client/src/components/Froms/QuestionForm.js
@@ -34,7 +34,10 @@ export default function PaymentForm(props) {
   };
   const handleAddQuestionClick = () => {
     const ques = questions[questions.length - 1];
-    if ((questions.length === 0) || (ques.question && ques.option1 && ques.option2 && ques.option3 && ques.option4)) {
+    if ((questions.length === 0) || 
+        (ques.question && ques.option1 &&
+          ques.option2 && ques.option3 && 
+          ques.option4 && ques.answer)) {
       setErrMsg("");
       setQuestions([
         ...questions,

--- a/client/src/components/Froms/QuestionForm.js
+++ b/client/src/components/Froms/QuestionForm.js
@@ -32,9 +32,9 @@ export default function PaymentForm(props) {
     setErrMsg("");
     setQuestions(list);
   };
-  const handleAddClick = () => {
+  const handleAddQuestionClick = () => {
     const ques = questions[questions.length - 1];
-    if (ques.question && ques.option1 && ques.option2 && ques.option3 && ques.option4) {
+    if ((questions.length === 0) || (ques.question && ques.option1 && ques.option2 && ques.option3 && ques.option4)) {
       setErrMsg("");
       setQuestions([
         ...questions,
@@ -147,7 +147,7 @@ export default function PaymentForm(props) {
         variant='contained'
         color='primary'
         className={classes.button}
-        onClick={handleAddClick}
+        onClick={handleAddQuestionClick}
       >
         Add
       </Button>

--- a/client/src/components/Froms/QuestionForm.js
+++ b/client/src/components/Froms/QuestionForm.js
@@ -26,11 +26,12 @@ export default function PaymentForm(props) {
     list[index][name] = value;
     setQuestions(list);
   };
-  const handleRemoveClick = (index) => {
+  const handleRemoveQuestionClick = (questionIndex) => {
     const list = [...questions];
-    list.pop();
     setErrMsg("");
-    setQuestions(list);
+    setQuestions(list.filter(
+      (value, index) => index !== questionIndex
+    ));
   };
   const handleAddQuestionClick = () => {
     const ques = questions[questions.length - 1];
@@ -141,6 +142,13 @@ export default function PaymentForm(props) {
                   onChange={(e) => handleChange(e, index)}
                 />
               </Grid>
+            <Button
+              variant='contained'
+              color='secondary'
+              onClick={() => handleRemoveQuestionClick(index)}
+            >
+              Delete
+            </Button>
             </React.Fragment>
           );
         })}
@@ -153,14 +161,6 @@ export default function PaymentForm(props) {
         onClick={handleAddQuestionClick}
       >
         Add
-      </Button>
-      <Button
-        variant='contained'
-        color='secondary'
-        className={classes.button}
-        onClick={handleRemoveClick}
-      >
-        Delete
       </Button>
     </React.Fragment>
   );


### PR DESCRIPTION
## Related Issuse
Currently, only the last question can be deleted. This patch allows any intermediate question to be deleted

Closes: #110 

#### Describe the changes you've made
* The App no longer crashes, if the add button is pressed when there are 0 questions
* Answers fields is now mandatory to create a new questions, this is consistent with the behavior of requiring all options to be filled
* Intermediate questions can be deleted

The code uses the vanillaJS array method `Array.filter` to remove the unwanted question. All modifications are done to `QuestionsForms.js` and doesn't include any side effects. 

This PR was separated from the overall QuestionForm redesign in #82 since it was starting to be too huge for a single PR. And would introduce a lot of merge conflicts and possibly break a lot of newer contributions.

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| 'C' always gets deleted | We can now delete 'B' |
| ![image](https://user-images.githubusercontent.com/12978899/111367410-b98d0d00-86ba-11eb-97d8-197e0053f466.png) | ![image](https://user-images.githubusercontent.com/12978899/111367253-8ba7c880-86ba-11eb-963b-3959cbf89cc7.png) |

