### PR TITLE
Restricted input length in CreateClass form

### DIFF
--- a/client/src/components/Froms/CreateClass.js
+++ b/client/src/components/Froms/CreateClass.js
@@ -60,7 +60,9 @@ export default function FormDialog(props) {
           <TextField
             error={!!classError}
             helperText={classError}
-
+            inputProps={{
+              maxlength: 12
+            }}
             autoFocus
             id='name'
             label='Class name'
@@ -82,6 +84,11 @@ export default function FormDialog(props) {
             error={!!subjectCodeError}
             autoFocus
             type="number"
+            onInput={(e) => {
+              e.target.value = Math.max(0, parseInt(e.target.value))
+              .toString()
+              .slice(0, 12);
+            }}
             helperText={subjectCodeError}
             margin='normal'
             id='subcode'


### PR DESCRIPTION
## Related Issuse

- The issue was that there was no restriction on the limit of input length in the class name and subject code while creating class.

Closes: #109

#### Describe the changes you've made

I have put a restriction of length limit 12 to the class code and subject code in the createClass form.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
