### PR TITLE
Add config/default.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 config/production.json
 client/.eslintcache
+config/default.json

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,0 @@
-{
-  "mongoURI": "mongodb+srv://manthan:ZeWehR7TyW0mJKDB@cluster0.9mzve.mongodb.net/myFirstDatabase?retryWrites=true&w=majority",
-  "jwtSecret": "mysecrettoken"
-}

--- a/config/default.json.sample
+++ b/config/default.json.sample
@@ -1,0 +1,4 @@
+{
+  "mongoURI": "mongodb+srv://<username>:<password>.mongodb.net/myFirstDatabase?retryWrites=true&w=majority",
+  "jwtSecret": "mysecrettoken" // preferably generated cryptographically
+}


### PR DESCRIPTION
## Related Issuse

default.json under the config folder has Mongo Uri in the file which is a sensitive information. Sensitive information such as API Tokens and in this case Mongo Uri with the username and password of the data base should not be committed to a public repository. Instead of loading sensitive data this way, one should use a .env file and provide a sample .env for contributors.

Closes: #152 

#### Describe the changes you've made

Added the config.json to .gitignore and added a config.json.sample file to repository.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
