### PR TITLE
Configures eslint and prettier for client

### DIFF
--- a/client/.eslintignore
+++ b/client/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+src/serviceWorker.js

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,0 +1,31 @@
+{
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": ["eslint:recommended",
+         "plugin:react/recommended"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react"
+    ],
+    "settings": {
+        "react": {
+          "version": "detect"
+        }
+    },
+    "rules": {
+        "react/prop-types": 0
+    }
+}

--- a/client/.prettierignore
+++ b/client/.prettierignore
@@ -1,0 +1,3 @@
+# Ignore artifacts:
+build
+coverage

--- a/client/.prettierrc.json
+++ b/client/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "trailingComma": "none",
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1159,9 +1159,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@eslint/eslintrc": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
-      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
@@ -1170,7 +1170,6 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -5532,12 +5531,12 @@
       }
     },
     "eslint": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.16.0.tgz",
-      "integrity": "sha512-iVWPS785RuDA4dWuhhgXTNrGxHHK3a8HLSMBgbbU59ruJDubUraXN8N5rn7kb8tG6sjg74eE0RA3YWT51eusEw==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
+      "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.2.2",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -5548,12 +5547,12 @@
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
-        "esquery": "^1.2.0",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -5561,7 +5560,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -5606,17 +5605,22 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "version": "13.8.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+          "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.20.2"
           }
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "supports-color": {
           "version": "7.2.0",
@@ -5627,9 +5631,9 @@
           }
         },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
     },
@@ -5640,6 +5644,12 @@
       "requires": {
         "confusing-browser-globals": "^1.0.10"
       }
+    },
+    "eslint-config-standard": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.2.tgz",
+      "integrity": "sha512-fx3f1rJDsl9bY7qzyX8SAtP8GBSk6MfXFaTfaGgk12aAYW4gJSyRm7dM790L6cbXv63fvjY4XeSzXnb4WM+SKw==",
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
@@ -5687,6 +5697,16 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
       }
     },
     "eslint-plugin-flowtype": {
@@ -5773,30 +5793,178 @@
         "language-tags": "^1.0.5"
       }
     },
-    "eslint-plugin-react": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
-      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
+    "eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
       "requires": {
-        "array-includes": "^3.1.1",
-        "array.prototype.flatmap": "^1.2.3",
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
+      "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.23.2.tgz",
+      "integrity": "sha512-AfjgFQB+nYszudkxRkTFu0UR1zEQig0ArVMPloKhxwlwkzaw/fBiH0QWcBBhZONlXqQC51+nfqFrkn4EzHcGBw==",
+      "requires": {
+        "array-includes": "^3.1.3",
+        "array.prototype.flatmap": "^1.2.4",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "object.entries": "^1.1.2",
-        "object.fromentries": "^2.0.2",
-        "object.values": "^1.1.1",
+        "minimatch": "^3.0.4",
+        "object.entries": "^1.1.3",
+        "object.fromentries": "^2.0.4",
+        "object.values": "^1.1.3",
         "prop-types": "^15.7.2",
-        "resolve": "^1.18.1",
-        "string.prototype.matchall": "^4.0.2"
+        "resolve": "^2.0.0-next.3",
+        "string.prototype.matchall": "^4.0.4"
       },
       "dependencies": {
+        "array-includes": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+          "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.2",
+            "get-intrinsic": "^1.1.1",
+            "is-string": "^1.0.5"
+          }
+        },
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "requires": {
             "esutils": "^2.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            }
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object.values": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+          "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.2",
+            "has": "^1.0.3"
+          }
+        },
+        "resolve": {
+          "version": "2.0.0-next.3",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
+          "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
           }
         }
       }
@@ -5937,9 +6105,9 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "requires": {
         "estraverse": "^5.1.0"
       },
@@ -6373,9 +6541,9 @@
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
     },
     "file-entry-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "requires": {
         "flat-cache": "^3.0.4"
       }
@@ -6531,9 +6699,9 @@
       }
     },
     "flatted": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
-      "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA=="
     },
     "flatten": {
       "version": "1.0.3",
@@ -7036,6 +7204,11 @@
       "requires": {
         "function-bind": "^1.1.1"
       }
+    },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -7645,31 +7818,23 @@
       }
     },
     "internal-slot": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",
-      "integrity": "sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
       "requires": {
-        "es-abstract": "^1.17.0-next.1",
+        "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
-        "side-channel": "^1.0.2"
+        "side-channel": "^1.0.4"
       },
       "dependencies": {
-        "es-abstract": {
-          "version": "1.17.7",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
           "requires": {
-            "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "has-symbols": "^1.0.1"
           }
         }
       }
@@ -7715,6 +7880,11 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -7722,6 +7892,14 @@
       "optional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "requires": {
+        "call-bind": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -7846,6 +8024,11 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
     },
     "is-obj": {
       "version": "1.0.1",
@@ -9816,6 +9999,16 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9842,6 +10035,11 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -10598,14 +10796,97 @@
       }
     },
     "object.fromentries": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.3.tgz",
-      "integrity": "sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
+      "integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
+        "es-abstract": "^1.18.0-next.2",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          },
+          "dependencies": {
+            "get-intrinsic": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+              "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+              "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+              }
+            }
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -12119,6 +12400,12 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
@@ -12963,6 +13250,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -13754,12 +14046,13 @@
       "optional": true
     },
     "side-channel": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
-      "integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "requires": {
-        "es-abstract": "^1.18.0-next.0",
-        "object-inspect": "^1.8.0"
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
     },
     "signal-exit": {
@@ -14394,17 +14687,109 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz",
-      "integrity": "sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz",
+      "integrity": "sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
+        "es-abstract": "^1.18.0-next.2",
         "has-symbols": "^1.0.1",
-        "internal-slot": "^1.0.2",
-        "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.3"
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.3.1",
+        "side-channel": "^1.0.4"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
+            "object-inspect": "^1.9.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          },
+          "dependencies": {
+            "get-intrinsic": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+              "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+              "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+              }
+            },
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            }
+          }
+        },
+        "is-callable": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-regex": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+          "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "regexp.prototype.flags": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+          "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "string.prototype.trimend": {
@@ -14613,14 +14998,37 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.0.4.tgz",
-      "integrity": "sha512-sBT4xRLdALd+NFBvwOz8bw4b15htyythha+q+DVZqy2RS08PPC8O2sZFgJYEY7bJvbCFKccs+WIZ/cd+xxTWCw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.3.0.tgz",
+      "integrity": "sha512-gM9kB7aNIuSagW89Fh+SdL49uhKnVSORxMcV72u/dfptFdqExInNn5M21wgq/Uf5UdJpsboFhNe/0SoNKjaxzg==",
       "requires": {
-        "ajv": "^6.12.4",
-        "lodash": "^4.17.20",
+        "ajv": "^8.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+          "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
     "tapable": {
@@ -15075,6 +15483,24 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        }
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -15322,9 +15748,9 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
     },
     "v8-to-istanbul": {
       "version": "7.0.0",
@@ -16565,6 +16991,18 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
       }
     },
     "which-module": {

--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint './src/**/*.{js,jsx}'"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -43,5 +44,10 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:5000/"
+  "proxy": "http://localhost:5000/",
+  "devDependencies": {
+    "eslint": "^7.24.0",
+    "eslint-plugin-react": "^7.23.2",
+    "prettier": "2.2.1"
+  }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -70,8 +70,7 @@ const App = () => {
   });
 
   const getTheme =
-    window.location.pathname === '/dashboard' ||
-    window.location.pathname.startsWith('/class/');
+    window.location.pathname === '/dashboard' || window.location.pathname.startsWith('/class/');
 
   return (
     <Provider store={store}>
@@ -80,8 +79,7 @@ const App = () => {
           <div
             className={classes.back}
             style={{
-              backgroundImage:
-                displayBackground && getTheme ? `url(${theme})` : null
+              backgroundImage: displayBackground && getTheme ? `url(${theme})` : null
             }}
           >
             <Navbar />
@@ -92,10 +90,7 @@ const App = () => {
               <Route component={NotFound} />
             </Switch>
             <Tooltip title="Change Theme">
-              <CreateIcon
-                onClick={handleClickOpen}
-                className={classes.editTheme}
-              />
+              <CreateIcon onClick={handleClickOpen} className={classes.editTheme} />
             </Tooltip>
             <ThemeDialog open={open} handleClose={handleClose} />
           </div>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,7 +15,7 @@ import { status } from './actions/auth';
 import setAuthToken from './utils/setAuthToken';
 import ThemeDialog from './components/themes/Theme';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   back: {
     backgroundSize: 'cover',
     backgroundPosition: 'center',

--- a/client/src/actions/auth.js
+++ b/client/src/actions/auth.js
@@ -1,7 +1,7 @@
 import api from '../utils/api';
 import { setAlert } from './alert';
-import Cookie from "js-cookie";
-import jwtDecode from "jwt-decode";
+import Cookie from 'js-cookie';
+import jwtDecode from 'jwt-decode';
 import {
   REGISTER_SUCCESS,
   USER_LOADED,
@@ -15,7 +15,7 @@ import {
 export const loadUser = () => async (dispatch) => {
   try {
     const res = await api.get('/auth');
-    dispatch({ type: SET_THEME, payload: res.data.theme })
+    dispatch({ type: SET_THEME, payload: res.data.theme });
     dispatch({
       type: USER_LOADED,
       payload: res.data
@@ -31,13 +31,13 @@ export const loadUser = () => async (dispatch) => {
 export const status = () => (dispatch) => {
   try {
     // decode the token
-    const tokenData = jwtDecode(Cookie.get('token'))
+    const tokenData = jwtDecode(Cookie.get('token'));
     const currentTime = Date.now();
-    const tokenExpireTime = new Date(0).setUTCSeconds(tokenData.exp)
+    const tokenExpireTime = new Date(0).setUTCSeconds(tokenData.exp);
 
     // store the current theme in localstorage
     localStorage.setItem('theme', localStorage.getItem('theme'));
-    dispatch({ type: SET_THEME, payload: localStorage.getItem('theme') })
+    dispatch({ type: SET_THEME, payload: localStorage.getItem('theme') });
 
     // check whethere token is expire or not
     if (currentTime > tokenExpireTime) {
@@ -56,7 +56,7 @@ export const status = () => (dispatch) => {
       type: AUTH_ERROR
     });
   }
-}
+};
 // Register User
 export const register = (formData) => async (dispatch) => {
   try {
@@ -92,12 +92,12 @@ export const login = (email, password) => async (dispatch) => {
     });
     // Add theme to localstorage
     localStorage.setItem('theme', res.data.theme);
-    dispatch({ type: SET_THEME, payload: localStorage.getItem('theme') })
+    dispatch({ type: SET_THEME, payload: localStorage.getItem('theme') });
 
     // set Cookie in browser
     Cookie.set('token', res.data.token);
 
-    window.location.href = "/dashboard"
+    window.location.href = '/dashboard';
   } catch (err) {
     const errors = err.response.data.errors;
 

--- a/client/src/actions/classroom.js
+++ b/client/src/actions/classroom.js
@@ -47,9 +47,7 @@ export const CreateClass = (formData) => async (dispatch) => {
 };
 
 // Leave current class
-export const LeaveClass = (code, history, redirect = false) => async (
-  dispatch
-) => {
+export const LeaveClass = (code, history, redirect = false) => async (dispatch) => {
   try {
     await api.delete(`/classrooms/${code}`);
     dispatch(setAlert('Class sucessfully removed.', 'danger'));

--- a/client/src/actions/test.js
+++ b/client/src/actions/test.js
@@ -1,13 +1,6 @@
 import api from '../utils/api';
 import { setAlert } from './alert';
-import {
-  GET_TESTS,
-  GET_TEST,
-  CREATE_TEST,
-  SUBMIT_TEST,
-  DELETE_TEST,
-  TEST_ERROR
-} from './types';
+import { GET_TESTS, GET_TEST, CREATE_TEST, SUBMIT_TEST, DELETE_TEST, TEST_ERROR } from './types';
 
 // Get tests
 export const getTests = (code) => async (dispatch) => {

--- a/client/src/actions/types.js
+++ b/client/src/actions/types.js
@@ -20,4 +20,4 @@ export const CREATE_TEST = 'CREATE_TEST';
 export const TEST_ERROR = 'TEST_ERROR';
 export const DELETE_TEST = 'DELETE_TEST';
 export const SUBMIT_TEST = 'SUBMIT_TEST';
-export const SET_THEME = "SET_THEME"
+export const SET_THEME = 'SET_THEME';

--- a/client/src/actions/ui.js
+++ b/client/src/actions/ui.js
@@ -1,15 +1,13 @@
 import api from '../utils/api';
-import { SET_THEME } from "./types";
-import { setAlert } from "./alert";
-export const saveTheme = (theme) => async dispatch => {
-
-    try {
-        const res = await api.post("/users/theme/", { theme });
-        localStorage.setItem('theme', theme);
-        dispatch({ type: SET_THEME, payload: theme })
-        dispatch(setAlert(res.data.message, "success"))
-    } catch (e) {
-        dispatch(setAlert("no theme update", "danger"))
-    }
-
-}
+import { SET_THEME } from './types';
+import { setAlert } from './alert';
+export const saveTheme = (theme) => async (dispatch) => {
+  try {
+    const res = await api.post('/users/theme/', { theme });
+    localStorage.setItem('theme', theme);
+    dispatch({ type: SET_THEME, payload: theme });
+    dispatch(setAlert(res.data.message, 'success'));
+  } catch (e) {
+    dispatch(setAlert('no theme update', 'danger'));
+  }
+};

--- a/client/src/components/auth/Login.js
+++ b/client/src/components/auth/Login.js
@@ -109,7 +109,7 @@ const Login = ({ login, isAuthenticated }) => {
           </Button>
           <Grid container>
             <Grid item>
-              Don't have an account?{' '}
+              Don#39;t have an account?{' '}
               <Link to="/register" variant="body2">
                 {'Sign Up'}
               </Link>

--- a/client/src/components/auth/Login.js
+++ b/client/src/components/auth/Login.js
@@ -44,8 +44,7 @@ const Login = ({ login, isAuthenticated }) => {
 
   const { email, password } = formData;
 
-  const onChange = (e) =>
-    setFormData({ ...formData, [e.target.name]: e.target.value });
+  const onChange = (e) => setFormData({ ...formData, [e.target.name]: e.target.value });
 
   const onSubmit = (e) => {
     e.preventDefault();

--- a/client/src/components/auth/Register.js
+++ b/client/src/components/auth/Register.js
@@ -46,8 +46,7 @@ const Register = ({ setAlert, register, isAuthenticated }) => {
 
   const { name, email, password, password2 } = formData;
 
-  const onChange = (e) =>
-    setFormData({ ...formData, [e.target.name]: e.target.value });
+  const onChange = (e) => setFormData({ ...formData, [e.target.name]: e.target.value });
 
   const onSubmit = async (e) => {
     e.preventDefault();

--- a/client/src/components/classroom/Classroom.js
+++ b/client/src/components/classroom/Classroom.js
@@ -1,4 +1,3 @@
-
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -19,12 +18,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import NotFound from '../layout/NotFound';
 import EditClass from './EditClass';
 import TestCard from './TestCard';
-import {
-  getClass,
-  LeaveClass,
-  getUsers,
-  removeUser
-} from '../../actions/classroom';
+import { getClass, LeaveClass, getUsers, removeUser } from '../../actions/classroom';
 import { getTests } from '../../actions/test';
 import { setAlert } from '../../actions/alert';
 import { Button, Grid } from '@material-ui/core';
@@ -93,9 +87,9 @@ const Classroom = ({
   setAlert,
   getTests,
   LeaveClass,
-  classroom: { classroom, users,  loading:classLoading },
-  auth: { user , loading:authLoading },
-  test: { tests , loading : testLoading },
+  classroom: { classroom, users, loading: classLoading },
+  auth: { user, loading: authLoading },
+  test: { tests, loading: testLoading },
   history,
   match
 }) => {
@@ -115,9 +109,7 @@ const Classroom = ({
     getTests(match.params.code);
   }, [getTests, match.params.code]);
   const onLinkClick = () => {
-    navigator.clipboard.writeText(
-      `${window.location.origin}/join/${classroom.code}`
-    );
+    navigator.clipboard.writeText(`${window.location.origin}/join/${classroom.code}`);
     setAlert('Invite Link Copied.');
   };
   const handleClick = (event) => {
@@ -144,16 +136,10 @@ const Classroom = ({
         <CardContent className={classes.content}>
           <div className={classes.details}>
             <Typography variant="h3">{classroom.name}</Typography>
-            <Typography variant="subtitle1">
-              Subject : {classroom.subject}
-            </Typography>
-            <Typography variant="subtitle1">
-              Instructor : {classroom.admin.name}
-            </Typography>
+            <Typography variant="subtitle1">Subject : {classroom.subject}</Typography>
+            <Typography variant="subtitle1">Instructor : {classroom.admin.name}</Typography>
             {admin === true ? (
-              <Typography variant="subtitle1">
-                Class code : {classroom.code}
-              </Typography>
+              <Typography variant="subtitle1">Class code : {classroom.code}</Typography>
             ) : null}
             <div style={{ display: 'flex' }}>
               <Button className={classes.copylink} onClick={onLinkClick}>
@@ -173,12 +159,7 @@ const Classroom = ({
                 >
                   <MoreVertIcon />
                 </IconButton>
-                <Menu
-                  anchorEl={anchorEl}
-                  keepMounted
-                  open={open}
-                  onClose={handleClose}
-                >
+                <Menu anchorEl={anchorEl} keepMounted open={open} onClose={handleClose}>
                   <MenuItem onClick={handleEditClass}>Edit</MenuItem>
                   <MenuItem
                     onClick={() => {
@@ -208,10 +189,7 @@ const Classroom = ({
             {classroom.users.length <= 1
               ? 'No Student enrolled in class or already removed!'
               : 'Delete Students from Class!'}
-            <CloseIcon
-              className={classes.close}
-              onClick={() => setDisplayUsers(false)}
-            />
+            <CloseIcon className={classes.close} onClick={() => setDisplayUsers(false)} />
           </Typography>
           <div className={classes.demo}>
             {users.map((user, index) => {
@@ -235,12 +213,7 @@ const Classroom = ({
           {tests.map((Test) => {
             return (
               <Grid key="1" item md={6} xs={12}>
-                <TestCard
-                  key={Test._id}
-                  id={Test._id}
-                  test={Test.test}
-                  admin={admin}
-                />
+                <TestCard key={Test._id} id={Test._id} test={Test.test} admin={admin} />
               </Grid>
             );
           })}

--- a/client/src/components/classroom/Classroom.js
+++ b/client/src/components/classroom/Classroom.js
@@ -1,3 +1,4 @@
+
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -233,7 +234,7 @@ const Classroom = ({
         <Grid container alignItems="flex-start" spacing={2}>
           {tests.map((Test) => {
             return (
-              <Grid item md={6} xs={12}>
+              <Grid key="1" item md={6} xs={12}>
                 <TestCard
                   key={Test._id}
                   id={Test._id}

--- a/client/src/components/classroom/CreateTest.js
+++ b/client/src/components/classroom/CreateTest.js
@@ -20,12 +20,7 @@ const FloatingButton = ({ text, href }) => {
   return (
     <div>
       <Tooltip title={text} aria-label="add">
-        <Fab
-          className={classes.addicon}
-          color="secondary"
-          href={href}
-          aria-label="add"
-        >
+        <Fab className={classes.addicon} color="secondary" href={href} aria-label="add">
           <AddIcon />
         </Fab>
       </Tooltip>

--- a/client/src/components/classroom/CreateTest.js
+++ b/client/src/components/classroom/CreateTest.js
@@ -5,7 +5,7 @@ import AddIcon from '@material-ui/icons/Add';
 import Fab from '@material-ui/core/Fab';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   addicon: {
     margin: 0,
     top: 'auto',

--- a/client/src/components/classroom/EditClass.js
+++ b/client/src/components/classroom/EditClass.js
@@ -47,11 +47,7 @@ const EditFrom = ({ open, setOpen, editClass, classroom: { classroom } }) => {
 
   return (
     <form autoComplete="off">
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="form-dialog-title"
-      >
+      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
         <DialogTitle id="form-dialog-title">Edit Class</DialogTitle>
         <DialogContent>
           <TextField

--- a/client/src/components/classroom/JoinClass.js
+++ b/client/src/components/classroom/JoinClass.js
@@ -21,11 +21,7 @@ const JoinForm = ({ JoinClass, match, history }) => {
 
   return (
     <div>
-      <Dialog
-        open={true}
-        onClose={handleClose}
-        aria-labelledby="form-dialog-title"
-      >
+      <Dialog open={true} onClose={handleClose} aria-labelledby="form-dialog-title">
         <DialogTitle id="form-dialog-title">Join class</DialogTitle>
         <DialogContent>
           <DialogContentText>

--- a/client/src/components/classroom/TestCard.js
+++ b/client/src/components/classroom/TestCard.js
@@ -65,9 +65,7 @@ const TestCard = ({ admin, test, id, deleteTest }) => {
         <div className={classes.details}>
           <Typography variant="h4">{test.name}</Typography>
           <Typography variant="subtitle1">Marks : {test.marks}</Typography>
-          <Typography variant="subtitle1">
-            Due Date : {dueDate.toLocaleDateString()}
-          </Typography>
+          <Typography variant="subtitle1">Due Date : {dueDate.toLocaleDateString()}</Typography>
           <Typography variant="subtitle1">
             {`Duration : ${duration.getHours()} hrs ${duration.getMinutes()} min`}
           </Typography>
@@ -84,12 +82,7 @@ const TestCard = ({ admin, test, id, deleteTest }) => {
               >
                 <MoreVertIcon />
               </IconButton>
-              <Menu
-                anchorEl={anchorEl}
-                keepMounted
-                open={open}
-                onClose={handleClose}
-              >
+              <Menu anchorEl={anchorEl} keepMounted open={open} onClose={handleClose}>
                 <MenuItem
                   onClick={() => {
                     handleClose();

--- a/client/src/components/dashboard/ClassButton.js
+++ b/client/src/components/dashboard/ClassButton.js
@@ -11,7 +11,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import JoinClass from './JoinClass';
 import CreateClass from './CreateClass';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   addicon: {
     margin: 0,
     top: 'auto',

--- a/client/src/components/dashboard/ClassCard.js
+++ b/client/src/components/dashboard/ClassCard.js
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme) => ({
 const ClassCard = ({ LeaveClass, Class }) => {
   const classes = useStyles();
   const truncate = (str, n) => {
-    return str?.length > n ? str.substr(0, n - 1) + '...' : str;
+    return str.length > n ? str.substr(0, n - 1) + '...' : str;
   };
 
   return (

--- a/client/src/components/dashboard/ClassCard.js
+++ b/client/src/components/dashboard/ClassCard.js
@@ -73,10 +73,7 @@ const ClassCard = ({ LeaveClass, Class }) => {
                 ? `url(` + image + `)`
                 : 'url(data:image/jpeg;base64,' +
                   btoa(
-                    Class.image.data.reduce(
-                      (data, byte) => data + String.fromCharCode(byte),
-                      ''
-                    )
+                    Class.image.data.reduce((data, byte) => data + String.fromCharCode(byte), '')
                   ) +
                   ')'
             }}

--- a/client/src/components/dashboard/CreateClass.js
+++ b/client/src/components/dashboard/CreateClass.js
@@ -60,11 +60,7 @@ const CreateForm = ({ open, setOpen, CreateClass }) => {
 
   return (
     <form autoComplete="off">
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="form-dialog-title"
-      >
+      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
         <DialogTitle id="form-dialog-title">Create Class</DialogTitle>
         <DialogContent>
           <TextField

--- a/client/src/components/dashboard/CreateClass.js
+++ b/client/src/components/dashboard/CreateClass.js
@@ -26,7 +26,7 @@ const CreateForm = ({ open, setOpen, CreateClass }) => {
   const [subjectCodeError, setSubjectCodeError] = React.useState('');
   const [imageError, setImageError] = React.useState('');
   const [image, setImage] = React.useState(null);
-  const handleClick = (editable) => {
+  const handleClick = () => {
     const name = document.getElementById('name').value;
     const subject = document.getElementById('subject').value;
     const subcode = document.getElementById('subcode').value;
@@ -111,7 +111,7 @@ const CreateForm = ({ open, setOpen, CreateClass }) => {
               color: 'white',
               cursor: 'pointer'
             }}
-            for="image"
+            htmlFor="image"
           >
             Upload class image
           </label>

--- a/client/src/components/dashboard/Dashboard.js
+++ b/client/src/components/dashboard/Dashboard.js
@@ -13,8 +13,7 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(4)
   },
   noClass: {
-    backgroundImage:
-      'url(https://www.gstatic.com/classroom/documents_floating_into_folder.png)',
+    backgroundImage: 'url(https://www.gstatic.com/classroom/documents_floating_into_folder.png)',
     position: 'relative',
     height: '450px',
     width: '370px',

--- a/client/src/components/dashboard/JoinClass.js
+++ b/client/src/components/dashboard/JoinClass.js
@@ -22,23 +22,13 @@ const JoinForm = ({ open, setOpen, JoinClass }) => {
 
   return (
     <div>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="form-dialog-title"
-      >
+      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
         <DialogTitle id="form-dialog-title">Join class</DialogTitle>
         <DialogContent>
           <DialogContentText>
             Ask your teacher for the class code, then enter it here.
           </DialogContentText>
-          <TextField
-            autoFocus
-            margin="dense"
-            id="code"
-            label="Class Code"
-            fullWidth
-          />
+          <TextField autoFocus margin="dense" id="code" label="Class Code" fullWidth />
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose} color="primary">

--- a/client/src/components/dashboard/handleFormError.js
+++ b/client/src/components/dashboard/handleFormError.js
@@ -6,7 +6,7 @@ export const createClassFormError = (
   setclassError,
   setSubjectCodeError,
   setSubjectError,
-  setImageError,
+  setImageError
 ) => {
   if (!name) setclassError('This field is required!');
   else setclassError('');
@@ -17,14 +17,11 @@ export const createClassFormError = (
   if (!subcode) setSubjectCodeError('This field is required!');
   else setSubjectCodeError('');
 
-
   if (image) {
-    var type = image.name.split(".").pop();
-    var support = ["jpg", "png", "jpeg"];
-    if (!support.includes(type))
-      setImageError("please upload valid image format")
+    var type = image.name.split('.').pop();
+    var support = ['jpg', 'png', 'jpeg'];
+    if (!support.includes(type)) setImageError('please upload valid image format');
   }
-
 
   if (!name || !subject || !subcode || (image && !support.includes(type))) return true;
   else return false;

--- a/client/src/components/layout/Landing.js
+++ b/client/src/components/layout/Landing.js
@@ -10,11 +10,7 @@ const Landing = () => {
       <div className={styles.sideDiv}></div>
       <Grid container className={styles.grid}>
         <Grid item md={6} xs={12} sm={12}>
-          <img
-            src={bookPenImg}
-            alt={bookPenImg}
-            className={styles.bookPenImg}
-          />
+          <img src={bookPenImg} alt={bookPenImg} className={styles.bookPenImg} />
         </Grid>
         <Grid item md={6} xs={12} sm={12}>
           <div className={styles.desc}>
@@ -22,12 +18,11 @@ const Landing = () => {
               A <strong>secure platform</strong> for online testing
             </h1>
             <p className={styles.descInfo}>
-              We provide an online testing platform that can be used to conduct
-              tests that are wrapped with all the necessary precautions to
-              reduce the chances of cheating. Here, the educator can create
-              classes and tests on a web portal and all the entered questions
-              will be randomly distributed among the students resulting in a
-              large number of sets.
+              We provide an online testing platform that can be used to conduct tests that are
+              wrapped with all the necessary precautions to reduce the chances of cheating. Here,
+              the educator can create classes and tests on a web portal and all the entered
+              questions will be randomly distributed among the students resulting in a large number
+              of sets.
             </p>
           </div>
         </Grid>

--- a/client/src/components/layout/Navbar.js
+++ b/client/src/components/layout/Navbar.js
@@ -92,10 +92,7 @@ const Navbar = ({
     </Link>
   );
   const toggleDrawer = (open) => (event) => {
-    if (
-      event.type === 'keydown' &&
-      (event.key === 'Tab' || event.key === 'Shift')
-    ) {
+    if (event.type === 'keydown' && (event.key === 'Tab' || event.key === 'Shift')) {
       return;
     }
     setState({ ...state, left: open });
@@ -173,19 +170,14 @@ const Navbar = ({
                     component="a"
                     style={{
                       backgroundColor:
-                        classroom && Class.code === classroom.code
-                          ? 'rgba(0, 0, 0, 0.25)'
-                          : 'white'
+                        classroom && Class.code === classroom.code ? 'rgba(0, 0, 0, 0.25)' : 'white'
                     }}
                     href={`/class/${Class.code}/`}
                   >
                     <ListItemIcon>
                       <ClassRoundedIcon />
                     </ListItemIcon>
-                    <ListItemText color="textPrimary">
-                      {' '}
-                      {truncate(Class.name, 12)}
-                    </ListItemText>
+                    <ListItemText color="textPrimary"> {truncate(Class.name, 12)}</ListItemText>
                   </ListItem>
                 );
               })
@@ -199,11 +191,7 @@ const Navbar = ({
             </ListItemIcon>
             <ListItemText>Setting</ListItemText>
           </ListItem>
-          <ListItem
-            button
-            component="a"
-            href="https://github.com/Manthan933/Manthan"
-          >
+          <ListItem button component="a" href="https://github.com/Manthan933/Manthan">
             <ListItemIcon>
               <GitHubIcon />
             </ListItemIcon>

--- a/client/src/components/layout/Navbar.js
+++ b/client/src/components/layout/Navbar.js
@@ -23,7 +23,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import { getClasses } from '../../actions/classroom';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     flexGrow: 1
   },
@@ -101,7 +101,7 @@ const Navbar = ({
     setState({ ...state, left: open });
   };
   const truncate = (str, n) => {
-    return str?.length > n ? str.substr(0, n - 1) + '...' : str;
+    return str.length > n ? str.substr(0, n - 1) + '...' : str;
   };
   const getNavbar = (
     <Toolbar>

--- a/client/src/components/layout/NotFound.js
+++ b/client/src/components/layout/NotFound.js
@@ -30,11 +30,7 @@ const NotFound = () => {
               />
             </pattern>
             <linearGradient paint="solid" id="linearGradient6096">
-              <stop
-                id="stop6094"
-                offset="0"
-                style={{ stopColor: '#000000', stopOpacity: 1 }}
-              />
+              <stop id="stop6094" offset="0" style={{ stopColor: '#000000', stopOpacity: 1 }} />
             </linearGradient>
           </defs>
           <g transform="translate(170.14515,0.038164)" id="layer1">

--- a/client/src/components/routing/PrivateRoute.js
+++ b/client/src/components/routing/PrivateRoute.js
@@ -4,21 +4,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Spinner from '../layout/Spinner';
 
-const PrivateRoute = ({
-  component: Component,
-  auth: { isAuthenticated, loading },
-  ...rest
-}) => (
+const PrivateRoute = ({ component: Component, auth: { isAuthenticated, loading }, ...rest }) => (
   <Route
     {...rest}
-    render={props =>
-      loading ? (
-        <Spinner />
-      ) : isAuthenticated ? (
-        <Component {...props} />
-      ) : (
-        <Redirect to="/login" />
-      )
+    render={(props) =>
+      loading ? <Spinner /> : isAuthenticated ? <Component {...props} /> : <Redirect to="/login" />
     }
   />
 );
@@ -27,7 +17,7 @@ PrivateRoute.propTypes = {
   auth: PropTypes.object.isRequired
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   auth: state.auth
 });
 

--- a/client/src/components/tests/CreateTest.js
+++ b/client/src/components/tests/CreateTest.js
@@ -16,8 +16,8 @@ import Spinner from '../layout/Spinner';
 const id = uuid();
 const CreateTest = ({
   getClass,
-  classroom: { classroom, loading:classLoading ,error},
-  auth: { user , loading : authLoading },
+  classroom: { classroom, loading: classLoading, error },
+  auth: { user, loading: authLoading },
   createTest,
   history,
   match
@@ -70,12 +70,7 @@ const CreateTest = ({
     switch (activeStep) {
       case 0:
         return (
-          <TestForm
-            test={test}
-            setTest={setTest}
-            handleBack={handleBack}
-            handleNext={handleNext}
-          />
+          <TestForm test={test} setTest={setTest} handleBack={handleBack} handleNext={handleNext} />
         );
       case 1:
         return (
@@ -100,7 +95,7 @@ const CreateTest = ({
         throw new Error('Unknown step');
     }
   };
-  if ((classLoading || authLoading || classroom===null) && error===null) return <Spinner />;
+  if ((classLoading || authLoading || classroom === null) && error === null) return <Spinner />;
   if (classroom && user && user._id === classroom.admin._id) {
     return <Container>{getStepContent()}</Container>;
   }

--- a/client/src/components/tests/QuestionForm.js
+++ b/client/src/components/tests/QuestionForm.js
@@ -1,24 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import {
-  Typography,
-  Paper,
-  Grid,
-  Button,
-  CssBaseline,
-  TextField
-} from '@material-ui/core';
+import { Typography, Paper, Grid, Button, CssBaseline, TextField } from '@material-ui/core';
 import { addCSVQues } from '../../actions/test';
 
-const QuestionForm = ({
-  questions,
-  setQuestion,
-  id,
-  handleNext,
-  addCSVQues,
-  handleBack
-}) => {
+const QuestionForm = ({ questions, setQuestion, id, handleNext, addCSVQues, handleBack }) => {
   const ques = {
     question: '',
     type: 1,
@@ -99,17 +85,8 @@ const QuestionForm = ({
         Questions Form
       </Typography>
       <Paper style={{ padding: 16 }}>
-        <form
-          onNext={handleSubmit}
-          style={{ marginTop: 20, marginBottom: 15, height: 35 }}
-        >
-          <input
-            type="file"
-            name="quesFile"
-            required
-            id="quesFile"
-            accept=".json,.csv"
-          />
+        <form onNext={handleSubmit} style={{ marginTop: 20, marginBottom: 15, height: 35 }}>
+          <input type="file" name="quesFile" required id="quesFile" accept=".json,.csv" />
           <button type="submit">Submit</button>
         </form>
         <Grid container alignItems="flex-start" spacing={2}>
@@ -209,12 +186,7 @@ const QuestionForm = ({
               })
             : null}
           <Grid item xs={12} style={{ marginTop: 16 }}>
-            <Button
-              type="button"
-              variant="contained"
-              color="sucess"
-              onClick={AddQuestion}
-            >
+            <Button type="button" variant="contained" color="sucess" onClick={AddQuestion}>
               Add new question
             </Button>
           </Grid>

--- a/client/src/components/tests/QuestionForm.js
+++ b/client/src/components/tests/QuestionForm.js
@@ -83,7 +83,7 @@ const QuestionForm = ({
       (json) => {
         addNewQuestions(json);
       },
-      (err) => {
+      () => {
         // not json
       }
     );

--- a/client/src/components/tests/RulesForm.js
+++ b/client/src/components/tests/RulesForm.js
@@ -1,13 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Typography,
-  Paper,
-  Grid,
-  Button,
-  CssBaseline,
-  TextField
-} from '@material-ui/core';
+import { Typography, Paper, Grid, Button, CssBaseline, TextField } from '@material-ui/core';
 
 const RuleForm = ({ Rules, setRule, handleSubmit, handleBack }) => {
   const rule = { type: 1, marks: 0, noofques: 0 };
@@ -93,12 +86,7 @@ const RuleForm = ({ Rules, setRule, handleSubmit, handleBack }) => {
               })
             : null}
           <Grid item xs={12} style={{ marginTop: 16 }}>
-            <Button
-              type="button"
-              variant="contained"
-              color="sucess"
-              onClick={AddRule}
-            >
+            <Button type="button" variant="contained" color="sucess" onClick={AddRule}>
               Add Rule
             </Button>
           </Grid>

--- a/client/src/components/tests/Test.js
+++ b/client/src/components/tests/Test.js
@@ -18,13 +18,7 @@ import NotFound from '../layout/NotFound';
 import { startTest, submitTest } from '../../actions/test';
 import Spinner from '../layout/Spinner';
 
-const Test = ({
-  startTest,
-  submitTest,
-  match,
-  test: { test, loading },
-  history
-}) => {
+const Test = ({ startTest, submitTest, match, test: { test, loading }, history }) => {
   React.useEffect(() => {
     startTest(match.params.id);
   }, [startTest, match.params.id]);
@@ -108,12 +102,7 @@ const Test = ({
                   </ol>
                 </Grid>
                 <Grid item style={{ marginTop: 16 }}>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    type="submit"
-                    disabled={submitting}
-                  >
+                  <Button variant="contained" color="primary" type="submit" disabled={submitting}>
                     Submit
                   </Button>
                 </Grid>
@@ -136,6 +125,4 @@ const mapStateToProps = (state) => ({
   test: state.test
 });
 
-export default connect(mapStateToProps, { startTest, submitTest })(
-  withRouter(Test)
-);
+export default connect(mapStateToProps, { startTest, submitTest })(withRouter(Test));

--- a/client/src/components/tests/Test.js
+++ b/client/src/components/tests/Test.js
@@ -42,7 +42,7 @@ const Test = ({
       </Typography>
       <Form
         onSubmit={onSubmit}
-        render={({ handleSubmit, reset, submitting, pristine, values }) => (
+        render={({ handleSubmit, submitting }) => (
           <form onSubmit={handleSubmit} noValidate>
             <Paper style={{ padding: 16 }}>
               <Grid container alignItems="flex-start" spacing={2}>

--- a/client/src/components/tests/Testform.js
+++ b/client/src/components/tests/Testform.js
@@ -82,7 +82,7 @@ const TestForm = ({ setTest, handleNext, test }) => {
           durationHrs: test.duration.getHours(),
           durationMins: test.duration.getMinutes()
         }}
-        render={({ handleSubmit, reset, submitting, pristine, values }) => (
+        render={({ handleSubmit, submitting }) => (
           <form onSubmit={handleSubmit} noValidate>
             <Paper style={{ padding: 16 }}>
               <Grid container alignItems="flex-start" spacing={2}>

--- a/client/src/components/tests/Testform.js
+++ b/client/src/components/tests/Testform.js
@@ -14,8 +14,7 @@ function DatePickerWrTestFormer(props) {
     ...rest
   } = props;
   const showError =
-    ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) &&
-    meta.touched;
+    ((meta.submitError && !meta.dirtySinceLastSubmit) || meta.error) && meta.touched;
 
   return (
     <DatePicker
@@ -139,12 +138,7 @@ const TestForm = ({ setTest, handleNext, test }) => {
                   </Grid>
                 </MuiPickersUtilsProvider>
                 <Grid item style={{ marginTop: 16 }}>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    type="submit"
-                    disabled={submitting}
-                  >
+                  <Button variant="contained" color="primary" type="submit" disabled={submitting}>
                     Next
                   </Button>
                 </Grid>

--- a/client/src/components/themes/Theme.js
+++ b/client/src/components/themes/Theme.js
@@ -11,7 +11,7 @@ import themes from "../../utils/themes";
 import { SET_THEME } from "../../actions/types";
 import { saveTheme } from "../../actions/ui";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
     titleSection: {
         padding: "10px 20px",
         display: "flex"
@@ -97,7 +97,7 @@ const Dashboard = (props) => {
                     {
                         themes.map((theme) => {
                             return (
-                                <img onClick={() => props.setTheme(theme)} className={props.activeTheme === theme ? classes.setTheme : classes.theme} src={theme} alt="sd" />
+                                <img onClick={() => props.setTheme(theme)} key={theme} className={props.activeTheme === theme ? classes.setTheme : classes.theme} src={theme} alt="sd" />
                             )
                         })
                     }

--- a/client/src/components/themes/Theme.js
+++ b/client/src/components/themes/Theme.js
@@ -7,129 +7,128 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import WallpaperIcon from '@material-ui/icons/Wallpaper';
 import Slide from '@material-ui/core/Slide';
-import themes from "../../utils/themes";
-import { SET_THEME } from "../../actions/types";
-import { saveTheme } from "../../actions/ui";
+import themes from '../../utils/themes';
+import { SET_THEME } from '../../actions/types';
+import { saveTheme } from '../../actions/ui';
 
 const useStyles = makeStyles(() => ({
-    titleSection: {
-        padding: "10px 20px",
-        display: "flex"
-    },
-    wallpaper: {
-        margin: "auto 0",
-        fontSize: "40px"
-    },
-    title: {
-        fontSize: "25px",
-        paddingLeft: "10px",
-        fontFamily: 'Roboto',
-        fontWeight: "bold",
-        letterSpacing: "2px"
-    },
+  titleSection: {
+    padding: '10px 20px',
+    display: 'flex'
+  },
+  wallpaper: {
+    margin: 'auto 0',
+    fontSize: '40px'
+  },
+  title: {
+    fontSize: '25px',
+    paddingLeft: '10px',
+    fontFamily: 'Roboto',
+    fontWeight: 'bold',
+    letterSpacing: '2px'
+  },
 
-    themesSection: {
-        display: "flex",
-        flexWrap: "wrap"
-    },
+  themesSection: {
+    display: 'flex',
+    flexWrap: 'wrap'
+  },
+  theme: {
+    width: '45%',
+    height: '150px',
+    margin: '10px',
+    cursor: 'pointer'
+  },
+  setTheme: {
+    width: '45%',
+    height: '150px',
+    margin: '10px',
+    cursor: 'pointer',
+    boxShadow: '10px 20px 10px black',
+    transition: '0.3s all'
+  },
+  button: {
+    padding: '10px 40px',
+    backgroundColor: 'black',
+    color: 'white',
+    width: '20%',
+    border: 'none',
+    fontSize: '15px',
+    borderRadius: '5px',
+    cursor: 'pointer'
+  },
+  '@media screen and (max-width: 500px)': {
     theme: {
-        width: "45%",
-        height: "150px",
-        margin: "10px",
-        cursor: "pointer"
-    },
-    setTheme: {
-        width: "45%",
-        height: "150px",
-        margin: "10px",
-        cursor: "pointer",
-        boxShadow: "10px 20px 10px black",
-        transition: "0.3s all"
-
-    },
-    button: {
-        padding: "10px 40px",
-        backgroundColor: "black",
-        color: "white",
-        width: "20%",
-        border: "none",
-        fontSize: "15px",
-        borderRadius: "5px",
-        cursor: "pointer"
-    },
-    '@media screen and (max-width: 500px)': {
-        theme: {
-            width: "100%",
-            height: "250px"
-        }
+      width: '100%',
+      height: '250px'
     }
+  }
 }));
 const Transition = React.forwardRef(function Transition(props, ref) {
-    return <Slide direction="up" ref={ref} {...props} />;
+  return <Slide direction="up" ref={ref} {...props} />;
 });
 
-
 const Dashboard = (props) => {
-    const classes = useStyles();
+  const classes = useStyles();
 
-    const { open, handleClose } = props;
-    const saveThemeCurr = () => {
-        props.saveTheme(props.activeTheme);
-        handleClose();
-    }
-    return (
-        <Dialog
+  const { open, handleClose } = props;
+  const saveThemeCurr = () => {
+    props.saveTheme(props.activeTheme);
+    handleClose();
+  };
+  return (
+    <Dialog
+      open={open}
+      TransitionComponent={Transition}
+      keepMounted
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-slide-title"
+      aria-describedby="alert-dialog-slide-description"
+    >
+      <div className={classes.titleSection}>
+        <WallpaperIcon className={classes.wallpaper} />
+        <p className={classes.title}>Choose Your Custom Theme</p>
+      </div>
 
-            open={open}
-            TransitionComponent={Transition}
-            keepMounted
-            onClose={handleClose}
-            aria-labelledby="alert-dialog-slide-title"
-            aria-describedby="alert-dialog-slide-description"
-        >
-            <div className={classes.titleSection}>
-                <WallpaperIcon className={classes.wallpaper} />
-                <p className={classes.title}>Choose Your Custom Theme</p>
-            </div>
-
-            <DialogContent>
-                <div className={classes.themesSection}>
-                    {
-                        themes.map((theme) => {
-                            return (
-                                <img onClick={() => props.setTheme(theme)} key={theme} className={props.activeTheme === theme ? classes.setTheme : classes.theme} src={theme} alt="sd" />
-                            )
-                        })
-                    }
-
-                </div>
-            </DialogContent>
-            {
-                props.activeTheme ? (
-                    <DialogActions>
-                        <button onClick={saveThemeCurr} className={classes.button}>Set</button>
-                    </DialogActions>
-                ) : null
-            }
-
-        </Dialog>
-    );
+      <DialogContent>
+        <div className={classes.themesSection}>
+          {themes.map((theme) => {
+            return (
+              <img
+                onClick={() => props.setTheme(theme)}
+                key={theme}
+                className={props.activeTheme === theme ? classes.setTheme : classes.theme}
+                src={theme}
+                alt="sd"
+              />
+            );
+          })}
+        </div>
+      </DialogContent>
+      {props.activeTheme ? (
+        <DialogActions>
+          <button onClick={saveThemeCurr} className={classes.button}>
+            Set
+          </button>
+        </DialogActions>
+      ) : null}
+    </Dialog>
+  );
 };
 
 Dashboard.propTypes = {
-    classroom: PropTypes.object.isRequired
+  classroom: PropTypes.object.isRequired
 };
 
 const mapStateToProps = (state) => ({
-    classroom: state.classroom,
-    activeTheme: state.ui.theme
+  classroom: state.classroom,
+  activeTheme: state.ui.theme
 });
 
 const mapDispatchToProps = (dispatch) => {
-    return {
-        setTheme: (theme) => dispatch({ type: SET_THEME, payload: theme }),
-        saveTheme: (theme) => dispatch(saveTheme(theme))
-    }
-}
+  return {
+    setTheme: (theme) => dispatch({ type: SET_THEME, payload: theme }),
+    saveTheme: (theme) => dispatch(saveTheme(theme))
+  };
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);

--- a/client/src/reducers/auth.js
+++ b/client/src/reducers/auth.js
@@ -1,10 +1,4 @@
-import {
-  REGISTER_SUCCESS,
-  USER_LOADED,
-  AUTH_ERROR,
-  LOGIN_SUCCESS,
-  LOGOUT
-} from '../actions/types';
+import { REGISTER_SUCCESS, USER_LOADED, AUTH_ERROR, LOGIN_SUCCESS, LOGOUT } from '../actions/types';
 
 const initialState = {
   token: localStorage.getItem('token'),

--- a/client/src/reducers/classroom.js
+++ b/client/src/reducers/classroom.js
@@ -46,9 +46,7 @@ function classroomReducer(state = initialState, action) {
     case LEAVE_CLASSROOM:
       return {
         ...state,
-        classrooms: state.classrooms.filter(
-          (classroom) => classroom.code !== payload
-        ),
+        classrooms: state.classrooms.filter((classroom) => classroom.code !== payload),
         loading: false
       };
     case CLASSROOM_ERROR:

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -3,7 +3,7 @@ import alert from './alert';
 import auth from './auth';
 import classroom from './classroom';
 import test from './test';
-import ui from "./ui";
+import ui from './ui';
 export default combineReducers({
   alert,
   auth,

--- a/client/src/reducers/ui.js
+++ b/client/src/reducers/ui.js
@@ -1,24 +1,22 @@
-import {
-    SET_THEME
-} from '../actions/types';
+import { SET_THEME } from '../actions/types';
 
 const initialState = {
-    theme: null,
+  theme: null
 };
 
 function testReducer(state = initialState, action) {
-    const { type, payload } = action;
+  const { type, payload } = action;
 
-    switch (type) {
-        case SET_THEME:
-            return {
-                ...state,
-                theme: payload
-            };
+  switch (type) {
+    case SET_THEME:
+      return {
+        ...state,
+        theme: payload
+      };
 
-        default:
-            return state;
-    }
+    default:
+      return state;
+  }
 }
 
 export default testReducer;

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -17,8 +17,8 @@ const api = axios.create({
 **/
 
 api.interceptors.response.use(
-  res => res,
-  err => {
+  (res) => res,
+  (err) => {
     if (err.response.status === 401) {
       store.dispatch({ type: LOGOUT });
     }

--- a/client/src/utils/setAuthToken.js
+++ b/client/src/utils/setAuthToken.js
@@ -1,6 +1,6 @@
 import api from './api';
 
-const setAuthToken = token => {
+const setAuthToken = (token) => {
   if (token) {
     api.defaults.headers.common['x-auth-token'] = token;
     localStorage.setItem('token', token);


### PR DESCRIPTION
Configures eslint and prettier for client

 - This patches configures eslint using
   `npm install eslint-plugin-react --save-dev`
   and the lint can be checked using `npm run lint` command

 - This patch also configures prettier to keep the code
   in a standard format using `npm install --save-dev --save-exact prettier`
   which can be formatted using `npx prettier --write ./src/`

 - Eslint warnings and errors
    
 - Preetify's the code using preetier command

Fixes: https://github.com/Manthan933/Manthan/issues/171


#### Describe the changes you've made

A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Screenshots

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |
